### PR TITLE
Fix address calculation issue in Parse 1 (RSUB handling)

### DIFF
--- a/Assembler.py
+++ b/Assembler.py
@@ -225,8 +225,9 @@ def stmt():
     tok = tokenval
     if pass1or2 == 2:
         inst = symtable[tokenval].att << 16
-    match('F3')
     locctr += 3
+    match('F3')
+    
     if symtable[tok].string != 'RSUB':
         inst += symtable[tokenval].att
         match('ID')


### PR DESCRIPTION
This pull request fixes an issue where the address calculation in parse1 produces incorrect results when the instruction is RSUB.